### PR TITLE
fix: relayUrl

### DIFF
--- a/src/utils/lit.ts
+++ b/src/utils/lit.ts
@@ -33,7 +33,6 @@ export const litNodeClient: LitNodeClient = new LitNodeClient({
 
 export const litAuthClient: LitAuthClient = new LitAuthClient({
   litRelayConfig: {
-    relayUrl: 'https://relay-server-staging.herokuapp.com',
     relayApiKey: 'test-api-key',
   },
   litNodeClient,


### PR DESCRIPTION
Not anymore passing a particular relayer URL while creating an `LitAuthClient` instance to prevent the demo to use the Serrano endpoint